### PR TITLE
pin mongo docker image tag to mongo:3.4.10

### DIFF
--- a/resources/mongodb-configdb-service.yaml
+++ b/resources/mongodb-configdb-service.yaml
@@ -46,7 +46,7 @@ spec:
             defaultMode: 256
       containers:
         - name: mongod-configdb-container
-          image: mongo
+          image: mongo:3.4.10
           command:
             - "numactl"
             - "--interleave=all"

--- a/resources/mongodb-maindb-service.yaml
+++ b/resources/mongodb-maindb-service.yaml
@@ -46,7 +46,7 @@ spec:
             defaultMode: 256
       containers:
         - name: mongod-shardX-container
-          image: mongo
+          image: mongo:3.4.10
           command:
             - "numactl"
             - "--interleave=all"

--- a/resources/mongodb-mongos-deployment.yaml
+++ b/resources/mongodb-mongos-deployment.yaml
@@ -31,7 +31,7 @@ spec:
             defaultMode: 256
       containers:
         - name: mongos-container
-          image: mongo
+          image: mongo:3.4.10
           command:
             - "numactl"
             - "--interleave=all"


### PR DESCRIPTION
Yesterday/today they changed the latest tag on mongo docker image from 3.4 -> 3.6
docker-library/official-images@9ab6d58#diff-c7d492b78482cdbec624f40bb1b722fd

that breaks quite a lot of things, 3.6 seems not to have --bind_ip_all by default and sh.addShard yields this error
```
mongos> sh.addShard("Shard4RepSet/mongod-shard4-0.mongodb-shard4-service.default.svc.cluster.local:27017");
{
        "code" : 96,
        "ok" : 0,
        "errmsg" : "can't add shard 'Shard4RepSet/mongod-shard4-0.mongodb-shard4-service.default.svc.cluster.local:27017' because a local database 'config' exists in another config"
}
```
I'd recommend pinning the mongo docker image - mongo:latest -> mongo:3.4.10